### PR TITLE
Add 'RESTRICTION' to valid datatypes

### DIFF
--- a/src/commonnexus/blocks/characters.py
+++ b/src/commonnexus/blocks/characters.py
@@ -423,7 +423,7 @@ class Format(Payload):
         if self.datatype:
             self.datatype = self.datatype.upper()
             assert self.datatype in {
-                'STANDARD', 'DNA', 'RNA', 'NUCLEOTIDE', 'PROTEIN', 'CONTINUOUS'}
+                'STANDARD', 'DNA', 'RNA', 'NUCLEOTIDE', 'PROTEIN', 'CONTINUOUS', 'RESTRICTION'}
             if self.datatype == 'CONTINUOUS' and not self.nexus.cfg.ignore_unsupported:
                 raise NotImplementedError('DATATYPE=CONTINUOUS is not supported!')
         self.items = [i.upper() for i in self.items]


### PR DESCRIPTION
In the good old days, for certain analyses, MrBayes wanted the nexus datatype for a characters block to be 'RESTRICTION' (i.e. https://en.wikipedia.org/wiki/Restriction_fragment_length_polymorphism). This datatype is identical to datatype ='STANDARD'